### PR TITLE
chore(post-input): comment out unfinished glow effects

### DIFF
--- a/src/app/(app)/whotofollow/page.tsx
+++ b/src/app/(app)/whotofollow/page.tsx
@@ -20,10 +20,10 @@ const Whotofollow = () => {
       try {
         // Directly fetch data
         const response = await axios.get("/api/user/follow/recommendation");
-        
+
         // Update query cache with fresh data
         queryClient.setQueryData(["users", null], response.data);
-        
+
         // Also prefetch to ensure consistent behavior
         queryClient.prefetchQuery({
           queryKey: ["users", null],
@@ -39,7 +39,7 @@ const Whotofollow = () => {
         }, 300);
       }
     };
-    
+
     fetchData();
   }, [queryClient]);
 
@@ -48,7 +48,7 @@ const Whotofollow = () => {
       toast.error("Please login to follow users");
       return;
     }
-    
+
     if (session.data?.user.id === userId) {
       toast.error("You cannot follow yourself");
       return;

--- a/src/app/settings/layout.tsx
+++ b/src/app/settings/layout.tsx
@@ -3,7 +3,7 @@ import React from "react";
 
 const ProfileLayout = ({ children }: { children: React.ReactNode }) => {
   return (
-    <div className="full h-screen overflow-y-scroll w-full flex-col overflow-hidden px-3 my-3 dark:bg-black">
+    <div className="full h-screen overflow-y-scroll w-full flex-col overflow-hidden px-3 py-3 dark:bg-black">
       <Navbar />
       <div className="flex-1">{children}</div>
     </div>

--- a/src/components/FeedbackButton.tsx
+++ b/src/components/FeedbackButton.tsx
@@ -22,7 +22,7 @@ export default function FeedbackButton({ position = "bottom-right", apiEndpoint 
   const [isOpen, setIsOpen] = useState(false)
   const [content, setContent] = useState("")
   const [severity, setSeverity] = useState("LOW")
-//   const { toast } = useToast()
+  //   const { toast } = useToast()
   const [isButtonHovered, setIsButtonHovered] = useState(false)
   const session = authClient.useSession()
   const [isClient, setIsClient] = useState(false)
@@ -123,7 +123,7 @@ export default function FeedbackButton({ position = "bottom-right", apiEndpoint 
           <div className="relative flex flex-col">
             {/* Glow effects */}
             <div className="absolute -right-4 size-40 -rotate-45 rounded-full border border-primary/50 bg-gradient-to-br from-primary/40 via-primary/50 to-transparent blur-[150px] backdrop-blur-sm"></div>
-            <div className="absolute -bottom-5 left-12 size-40 rotate-45 rounded-full border border-secondary/50 bg-gradient-to-tl from-secondary/40 via-secondary/30 to-transparent blur-[150px] backdrop-blur-sm"></div>
+            {/* <div className="absolute -bottom-5 left-12 size-40 rotate-45 rounded-full border border-secondary/50 bg-gradient-to-tl from-secondary/40 via-secondary/30 to-transparent blur-[150px] backdrop-blur-sm"></div> */}
 
             <div className="flex w-full flex-col px-7 pb-4">
               <DialogHeader>

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -109,8 +109,8 @@ const Navbar = () => {
 
               <div className="relative flex flex-col px-6 pb-4">
                 {/* Glow effects */}
-                <div className="absolute hidden md:block -right-4 size-32 -rotate-45 rounded-full border border-blue-300/50 bg-gradient-to-br from-blue-300/40 via-blue-400/50 to-transparent blur-[150px] backdrop-blur-sm"></div>
-                <div className="absolute hidden md:block -bottom-5 left-12 size-32 rotate-45 rounded-full border border-orange-300/50 bg-gradient-to-tl from-orange-300/40 via-orange-400/30 to-transparent blur-[150px] backdrop-blur-sm"></div>
+                {/* <div className="absolute hidden md:block -right-4 size-32 -rotate-45 rounded-full border border-blue-300/50 bg-gradient-to-br from-blue-300/40 via-blue-400/50 to-transparent blur-[150px] backdrop-blur-sm"></div> */}
+                {/* <div className="absolute hidden md:block -bottom-5 left-12 size-32 rotate-45 rounded-full border border-orange-300/50 bg-gradient-to-tl from-orange-300/40 via-orange-400/30 to-transparent blur-[150px] backdrop-blur-sm"></div> */}
 
                 <CommandInput
                   value={query}

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -167,7 +167,7 @@ const Navbar = () => {
                   <>
                     <AvatarImage
                       src={user.image || "/user.jpg"}
-                      className="size-8 rounded-full"
+                      className="size-8 rounded-full object-cover"
                       alt="@shadcn"
                     />
                     <AvatarFallback className="">

--- a/src/components/post/post-card.tsx
+++ b/src/components/post/post-card.tsx
@@ -61,22 +61,22 @@ import { SmileIcon } from "lucide-react";
 
 const timeAgo = (date: Date) => {
   const seconds = Math.floor((new Date().getTime() - new Date(date).getTime()) / 1000);
-  
+
   let interval = seconds / 31536000;
   if (interval > 1) return Math.floor(interval) + 'y';
-  
+
   interval = seconds / 2592000;
   if (interval > 1) return Math.floor(interval) + 'mo';
-  
+
   interval = seconds / 86400;
   if (interval > 1) return Math.floor(interval) + 'd';
-  
+
   interval = seconds / 3600;
   if (interval > 1) return Math.floor(interval) + 'h';
-  
+
   interval = seconds / 60;
   if (interval > 1) return Math.floor(interval) + 'm';
-  
+
   return Math.floor(seconds) + 's';
 };
 
@@ -230,12 +230,12 @@ const PostCard = ({
                   ...p,
                   likes: isLiked
                     ? p.likes.filter(
-                        (like: any) => like.userId !== session.data?.user.id,
-                      )
+                      (like: any) => like.userId !== session.data?.user.id,
+                    )
                     : [
-                        ...p.likes,
-                        { userId: session.data?.user.id, postId: p.id },
-                      ],
+                      ...p.likes,
+                      { userId: session.data?.user.id, postId: p.id },
+                    ],
                   _count: {
                     ...p._count,
                     likes: isLiked ? p._count.likes - 1 : p._count.likes + 1,
@@ -301,13 +301,13 @@ const PostCard = ({
                   ...p,
                   bookmarks: isBookmarked
                     ? p.bookmarks.filter(
-                        (bookmark: any) =>
-                          bookmark.userId !== session.data?.user.id,
-                      )
+                      (bookmark: any) =>
+                        bookmark.userId !== session.data?.user.id,
+                    )
                     : [
-                        ...p.bookmarks,
-                        { userId: session.data?.user.id, postId: p.id },
-                      ],
+                      ...p.bookmarks,
+                      { userId: session.data?.user.id, postId: p.id },
+                    ],
                   _count: {
                     ...p._count,
                     bookmarks: isBookmarked
@@ -598,7 +598,7 @@ const PostCard = ({
                     <span>Delete</span>
                   </DropdownMenuItem>
                   {(post?.access as unknown as string) ===
-                  (PostAccess.public as unknown as string) ? (
+                    (PostAccess.public as unknown as string) ? (
                     <DropdownMenuItem
                       onClick={() => {
                         handleAccessChange();
@@ -832,8 +832,8 @@ const PostCard = ({
                     ? "liked"
                     : "initial"
                   : post.likes?.some(
-                        (like) => like.userId === session.data?.user.id,
-                      )
+                    (like) => like.userId === session.data?.user.id,
+                  )
                     ? "liked"
                     : "initial"
               }
@@ -848,8 +848,8 @@ const PostCard = ({
                   <GoHeart className="size-5" />
                 )
               ) : post.likes?.some(
-                  (like) => like.userId === session.data?.user.id,
-                ) ? (
+                (like) => like.userId === session.data?.user.id,
+              ) ? (
                 <GoHeartFill className="size-5 text-red-500" />
               ) : (
                 <GoHeart className="size-5" />
@@ -890,8 +890,8 @@ const PostCard = ({
                     ? "bookmarked"
                     : "initial"
                   : post.bookmarks.some(
-                        (bookmark) => bookmark.userId === session.data?.user.id,
-                      )
+                    (bookmark) => bookmark.userId === session.data?.user.id,
+                  )
                     ? "bookmarked"
                     : "initial"
               }
@@ -906,8 +906,8 @@ const PostCard = ({
                   <HiOutlineBookmark className="size-5" />
                 )
               ) : post.bookmarks.some(
-                  (bookmark) => bookmark.userId === session.data?.user.id,
-                ) ? (
+                (bookmark) => bookmark.userId === session.data?.user.id,
+              ) ? (
                 <HiBookmark className="size-5 text-primary" />
               ) : (
                 <HiOutlineBookmark className="size-5" />
@@ -1025,13 +1025,13 @@ const PostCard = ({
               <div className="flex w-full flex-col px-6 pb-3">
                 <div className="mb-2 font-geist text-3xl font-medium">
                   {(post.access as unknown as string) ===
-                  (PostAccess.public as unknown as string)
+                    (PostAccess.public as unknown as string)
                     ? "Make Post Private"
                     : "Make Post Public"}
                 </div>
                 <p className="mb-6 font-geist text-muted-foreground">
                   {(post.access as unknown as string) ===
-                  (PostAccess.public as unknown as string)
+                    (PostAccess.public as unknown as string)
                     ? "Are you sure you want to make this post private? This will hide it from other users."
                     : "Are you sure you want to make this post public? This will make it visible to other users."}
                 </p>

--- a/src/components/post/post-input.tsx
+++ b/src/components/post/post-input.tsx
@@ -226,7 +226,7 @@ const PostInput = () => {
               size="sm"
               className="flex items-center gap-2 rounded-lg text-sm font-medium text-gray-600 dark:text-gray-300"
             >
-              <HiPhoto />
+              <HiPhoto className="size-4" />
               Photo
             </Button>
             <Button
@@ -235,7 +235,7 @@ const PostInput = () => {
               size="sm"
               className="flex items-center gap-2 rounded-lg text-sm font-medium text-gray-600 dark:text-gray-300"
             >
-              <FolderIcon />
+              <FolderIcon className="size-4" />
               <span className="hidden md:block">Document</span>
             </Button>
             <Button
@@ -244,7 +244,7 @@ const PostInput = () => {
               size="sm"
               className="flex items-center gap-2 rounded-lg text-sm font-medium text-gray-600 dark:text-gray-300"
             >
-              <MessagesSquareIcon />
+              <MessagesSquareIcon className="size-4" />
               <span className="hidden md:block">Poll</span>
             </Button>
           </div>

--- a/src/components/post/post-input.tsx
+++ b/src/components/post/post-input.tsx
@@ -270,8 +270,8 @@ const PostInput = () => {
           >
             <div className="relative">
               {/* Glow effects */}
-              <div className="absolute -right-4 size-32 -rotate-45 rounded-full border border-primary/50 bg-gradient-to-br from-primary/40 via-primary/50 to-transparent blur-[150px] backdrop-blur-sm"></div>
-              <div className="absolute -bottom-5 left-12 size-32 rotate-45 rounded-full border border-secondary/50 bg-gradient-to-tl from-secondary/40 via-secondary/30 to-transparent blur-[150px] backdrop-blur-sm"></div>
+              {/* <div className="absolute -right-4 size-32 -rotate-45 rounded-full border border-primary/50 bg-gradient-to-br from-primary/40 via-primary/50 to-transparent blur-[150px] backdrop-blur-sm"></div> */}
+              {/* <div className="absolute -bottom-5 left-12 size-32 rotate-45 rounded-full border border-secondary/50 bg-gradient-to-tl from-secondary/40 via-secondary/30 to-transparent blur-[150px] backdrop-blur-sm"></div> */}
 
               <div className="border-b border-gray-200 px-6 py-4 dark:border-black">
                 <DialogTitle className="text-xl font-semibold tracking-tight">

--- a/src/components/user/recommend-project.tsx
+++ b/src/components/user/recommend-project.tsx
@@ -53,7 +53,7 @@ export default function RecommendedProjects() {
     <Card className="hidden w-64 min-h-32 rounded-2xl border border-gray-100 bg-transparent pt-4 shadow-none dark:border-gray-500/5 md:block">
       <div className="relative">
         {/* Subtle gradient background effects */}
-        <div className="absolute -right-4 size-32 -rotate-45 rounded-full border border-primary/10 bg-gradient-to-br from-primary/5 to-transparent blur-[150px] backdrop-blur-sm"></div>
+        {/* <div className="absolute -right-4 size-32 -rotate-45 rounded-full border border-primary/10 bg-gradient-to-br from-primary/5 to-transparent blur-[150px] backdrop-blur-sm"></div> */}
 
         <h2
           onClick={() => {


### PR DESCRIPTION
## Refactor: Remove Unfinished Glow Effects and Standardize Image Sizes


1.  **Removal of Incomplete Glow Effects:** The glow effects appeared unfinished and were looking like random circles. I commented them out for the time being

    <table>
      <tr>
        <td align="center"><strong>Before</strong></td>
        <td align="center"><strong>After</strong></td>
      </tr>
      <tr>
        <td><img src="https://github.com/user-attachments/assets/d8380069-8864-455a-b4ce-781ebe998853" alt="Before"></td>
        <td><img src="https://github.com/user-attachments/assets/c1b7d99c-9b36-489a-99ec-c966128e1245" alt="After"></td>
      </tr>
    </table>

2.  made the size of this icon's equal too 😉

    <table>
      <tr>
        <td align="center"><strong>Before</strong></td>
        <td align="center"><strong>After</strong></td>
      </tr>
      <tr>
        <td><img src="https://github.com/user-attachments/assets/968110ed-62d3-4b5a-a903-89db248a488d" alt="Before" width="300"></td>
        <td><img src="https://github.com/user-attachments/assets/caa55b6e-252b-4b3a-af35-8e73da77f4c8" alt="After" width="300"></td>
      </tr>
    </table>
 
 3. fixed also the double scrollbar in the settings page by using a padding instead of margins 
 <table>
      <tr>
        <td align="center"><strong>Before</strong></td>
        <td align="center"><strong>After</strong></td>
      </tr>
      <tr>
        <td><img src="https://github.com/user-attachments/assets/39b4397c-fe4b-4aaf-aa0e-a57c1a6219ab" alt="Before" width="300"></td>
        <td><img src="https://github.com/user-attachments/assets/85b88222-e364-4b72-b693-9887ebb7cadd" alt="After" width="300"></td>
      </tr>
    </table>
4. also fixed distorted images when using large images as a pfp
 <table>
      <tr>
        <td align="center"><strong>Before</strong></td>
        <td align="center"><strong>After</strong></td>
      </tr>
      <tr>
        <td><img src="https://github.com/user-attachments/assets/75bcfd44-b833-48bc-b644-bb208b931bd8" alt="Before" width="300"></td>
        <td><img src="https://github.com/user-attachments/assets/15dd0698-dca6-4a59-9c20-77bb3e9aaa18" alt="After" width="300"></td>
      </tr>
    </table>

> ⚠️ **WARNING:** This may be unwanted, so we must build a modal that appears when you change your profile picture. This modal will allow you to choose to crop the image or change its fitting style.
